### PR TITLE
fix: 存在しない記事ページでレイアウトが崩れる問題を修正

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -22,6 +22,9 @@ const config = {
       $routes: "./src/routes",
       types: "./src/types",
     },
+    paths: {
+      relative: false,
+    },
     prerender: {
       entries: [
         "/404/",


### PR DESCRIPTION
## 概要
- SvelteKit 設定に `kit.paths.relative = false` を追加
- 404ページで読み込むアセットを絶対パス（`/_app/...`）で参照するように変更
- `/archives/29222/` のような深いURLで404になった際の CSS/JS 読み込み失敗を防止

## 確認内容
- `npm run build` 実行後、生成された `.svelte-kit/output/prerendered/pages/404/index.html` の参照が絶対パスになっていることを確認
- この環境では Contentful への名前解決エラー（`getaddrinfo EAI_AGAIN cdn.contentful.com`）により、ビルドは後段で停止
- `npm run format` 実行（追加差分なし）

Closes #488
