### PR TITLE
デプロイ結果の Slack 通知を追加

### DIFF
--- a/.github/workflows/cloudflare-pages-deploy.yml
+++ b/.github/workflows/cloudflare-pages-deploy.yml
@@ -50,3 +50,35 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: pages deploy build --project-name=k2ss-info --branch=main
+
+
+  notify:
+    if: ${{ always() && (needs.build_and_deploy.result == 'success' || needs.build_and_deploy.result == 'failure') }}
+    needs:
+      - build_and_deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify to Slack
+        uses: slackapi/slack-github-action@v3.0.3
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: "${{ needs.build_and_deploy.result == 'success' && ':white_check_mark: Deploy succeeded' || ':x: Deploy failed' }}"
+            blocks:
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "${{ needs.build_and_deploy.result == 'success' && ':white_check_mark: *Deploy succeeded*' || ':x: *Deploy failed*' }}"
+              - type: section
+                fields:
+                  - type: mrkdwn
+                    text: "*Repository:*\n<${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}>"
+              - type: actions
+                elements:
+                  - type: button
+                    text:
+                      type: plain_text
+                      text: View workflow
+                    url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    action_id: view_workflow

--- a/.github/workflows/cloudflare-pages-deploy.yml
+++ b/.github/workflows/cloudflare-pages-deploy.yml
@@ -13,6 +13,9 @@ on:
     types:
       - upload_entry
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -50,7 +53,6 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: pages deploy build --project-name=k2ss-info --branch=main
-
 
   notify:
     if: ${{ always() && (needs.build_and_deploy.result == 'success' || needs.build_and_deploy.result == 'failure') }}


### PR DESCRIPTION
## 概要
- Firebase Hosting / Cloudflare Pages の deploy workflow に Slack 通知を追加
- deploy の成功・失敗のみ Slack に通知
- 通知内容を成否アイコン、Repository リンク、Workflow リンクに整理

## 確認
- mise x actionlint -- actionlint 対象 workflow